### PR TITLE
Support kernel 6.x

### DIFF
--- a/st25r391x_i2c.c
+++ b/st25r391x_i2c.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA
  */
 
-#include <stdarg.h>
+#include <linux/stdarg.h>
 
 #include "st25r391x_i2c.h"
 #include "st25r391x_commands.h"

--- a/st25r391x_main.c
+++ b/st25r391x_main.c
@@ -35,7 +35,9 @@
 #include <linux/delay.h>
 #include <linux/i2c.h>
 #include <linux/circ_buf.h>
-#include <stdarg.h>
+#include <linux/stdarg.h>
+
+#include <linux/version.h>
 
 #include "st25r391x.h"
 
@@ -86,7 +88,11 @@ static long st25r391x_unlocked_ioctl(struct file *file, unsigned int,
 
 static int st25r391x_i2c_probe(struct i2c_client *i2c,
 			       const struct i2c_device_id *id);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,0,0)
 static int st25r391x_i2c_remove(struct i2c_client *client);
+#else
+static void st25r391x_i2c_remove(struct i2c_client *client);
+#endif
 
 // ========================================================================== //
 // Polling code
@@ -856,7 +862,11 @@ static int st25r391x_i2c_probe(struct i2c_client *i2c,
 	return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,0,0)
 static int st25r391x_i2c_remove(struct i2c_client *client)
+#else
+static void st25r391x_i2c_remove(struct i2c_client *client)
+#endif
 {
 	struct st25r391x_i2c_data *priv;
 	priv = i2c_get_clientdata(client);
@@ -877,7 +887,9 @@ static int st25r391x_i2c_remove(struct i2c_client *client)
 	del_timer_sync(&priv->polling_timer);
 	cancel_work_sync(&priv->polling_work);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,0,0)
 	return 0;
+#endif
 }
 
 #ifdef CONFIG_OF


### PR DESCRIPTION
Support building NFC driver on 6.x kernel.

Driver appears to run nicely on kernel 6.1.21.
**Note**: this unfortunately doesn't solve https://github.com/pguyot/st25r391x/issues/5...